### PR TITLE
feat: add Corporation Departed/Joined retrieve API

### DIFF
--- a/www/controllers/api.js
+++ b/www/controllers/api.js
@@ -10,6 +10,12 @@ async function getData(req, res) {
   if (req.params.type == 'character') return getChar(req, res);
   if (req.params.type == 'corplist') return getCorp(req, res);
   if (req.params.type == 'allilist') return getAlli(req, res);
+  
+  // CorpDeparted, change path if needed, this is draft!
+  if (req.params.type == 'corpdeparted') return getCorpDeparted(req, res);
+  // CorpJoined, change path if needed, this is draft!
+  if (req.params.type == 'corpjoined') return getCorpJoined(req, res);
+
   return {json: {}};
 }
 
@@ -47,3 +53,36 @@ async function getAlli(req, res) {
   return { json: {info: info, characters: characters}};
 }
 
+async function getCorpDeparted(req, res) {
+  const app = req.app.app;
+  
+  // TODO: Need to check compatibility, since Nullish coalscing needs node 14 at least.
+  const page = (req.query.page ?? 0)
+  const offset = 50 * (page - 1)
+  const info = await app.mysql.query('select corporation_id, name, memberCount from ew_corporations where is_npc_corp = 0 and corporation_id > 0 and corporation_id = ? limit 1', req.params.id);
+  
+  if (info.length == 0)return {status_code: 404} // 404;
+
+  query = 'select h.character_id id, name, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history h left join ew_characters c on h.character_id = c.character_id where end_date is not null and h.corporation_id = ? order by end_date desc limit 50 offset ?' 
+
+  const result = await app.mysql.query(query, [req.params.id, offset]) 
+  
+  return { json: {info: info, page: page, characters: result} } 
+}
+
+async function getCorpJoined(req, res) {
+  const app = req.app.app;
+  
+  // TODO: Need to check compatibility, since Nullish coalscing needs node 14 at least.
+  const page = (req.query.page ?? 0)
+  const offset = 50 * (page - 1)
+  const info = await app.mysql.query('select corporation_id, name, memberCount from ew_corporations where is_npc_corp = 0 and corporation_id > 0 and corporation_id = ? limit 1', req.params.id);
+  
+  if (info.length == 0)return {status_code: 404} // 404;
+
+  query = 'select h.character_id id, name, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history h left join ew_characters c on h.character_id = c.character_id where h.corporation_id = ? order by start_date desc limit 50 offset ?'
+  
+  const result = await app.mysql.query(query, [req.params.id, offset]) 
+  
+  return { json: {info: info, page: page, characters: result} } 
+}

--- a/www/controllers/api.js
+++ b/www/controllers/api.js
@@ -58,12 +58,12 @@ async function getCorpDeparted(req, res) {
   
   // TODO: Need to check compatibility, since Nullish coalscing needs node 14 at least.
   const page = (req.query.page ?? 0)
-  const offset = 50 * (page - 1)
+  const offset = 300 * (page - 1)
   const info = await app.mysql.query('select corporation_id, name, memberCount from ew_corporations where is_npc_corp = 0 and corporation_id > 0 and corporation_id = ? limit 1', req.params.id);
   
   if (info.length == 0)return {status_code: 404} // 404;
 
-  query = 'select h.character_id id, name, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history h left join ew_characters c on h.character_id = c.character_id where end_date is not null and h.corporation_id = ? order by end_date desc limit 50 offset ?' 
+  query = 'select character_id id, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history where end_date is not null and corporation_id = ? order by end_date desc limit 300 offset ?' 
 
   const result = await app.mysql.query(query, [req.params.id, offset]) 
   
@@ -75,12 +75,12 @@ async function getCorpJoined(req, res) {
   
   // TODO: Need to check compatibility, since Nullish coalscing needs node 14 at least.
   const page = (req.query.page ?? 0)
-  const offset = 50 * (page - 1)
+  const offset = 500 * (page - 1)
   const info = await app.mysql.query('select corporation_id, name, memberCount from ew_corporations where is_npc_corp = 0 and corporation_id > 0 and corporation_id = ? limit 1', req.params.id);
   
   if (info.length == 0)return {status_code: 404} // 404;
 
-  query = 'select h.character_id id, name, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history h left join ew_characters c on h.character_id = c.character_id where h.corporation_id = ? order by start_date desc limit 50 offset ?'
+  query = 'select character_id id, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history where h.corporation_id = ? order by start_date desc limit 500 offset ?'
   
   const result = await app.mysql.query(query, [req.params.id, offset]) 
   

--- a/www/controllers/api.js
+++ b/www/controllers/api.js
@@ -11,9 +11,7 @@ async function getData(req, res) {
   if (req.params.type == 'corplist') return getCorp(req, res);
   if (req.params.type == 'allilist') return getAlli(req, res);
   
-  // CorpDeparted, change path if needed, this is draft!
   if (req.params.type == 'corpdeparted') return getCorpDeparted(req, res);
-  // CorpJoined, change path if needed, this is draft!
   if (req.params.type == 'corpjoined') return getCorpJoined(req, res);
 
   return {json: {}};
@@ -56,33 +54,27 @@ async function getAlli(req, res) {
 async function getCorpDeparted(req, res) {
   const app = req.app.app;
   
-  // TODO: Need to check compatibility, since Nullish coalscing needs node 14 at least.
-  const page = (req.query.page ?? 0)
-  const offset = 300 * (page - 1)
   const info = await app.mysql.query('select corporation_id, name, memberCount from ew_corporations where is_npc_corp = 0 and corporation_id > 0 and corporation_id = ? limit 1', req.params.id);
   
-  if (info.length == 0)return {status_code: 404} // 404;
+  if (info.length == 0) return {status_code: 404} // 404;
 
-  query = 'select character_id id, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history where end_date is not null and corporation_id = ? order by end_date desc limit 300 offset ?' 
+  query = 'select character_id id, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history where end_date is not null and corporation_id = ? order by end_date desc limit 500'
 
-  const result = await app.mysql.query(query, [req.params.id, offset]) 
+  const result = await app.mysql.query(query, [req.params.id]) 
   
-  return { json: {info: info, page: page, characters: result} } 
+  return { json: {characters: result} } 
 }
 
 async function getCorpJoined(req, res) {
   const app = req.app.app;
   
-  // TODO: Need to check compatibility, since Nullish coalscing needs node 14 at least.
-  const page = (req.query.page ?? 0)
-  const offset = 500 * (page - 1)
   const info = await app.mysql.query('select corporation_id, name, memberCount from ew_corporations where is_npc_corp = 0 and corporation_id > 0 and corporation_id = ? limit 1', req.params.id);
   
-  if (info.length == 0)return {status_code: 404} // 404;
+  if (info.length == 0) return {status_code: 404} // 404;
 
-  query = 'select character_id id, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history where h.corporation_id = ? order by start_date desc limit 500 offset ?'
+  query = 'select character_id id, date_format(start_date, "%Y/%m/%d %H:%i") start_date, date_format(end_date, "%Y/%m/%d %H:%i") end_date from ew_history where h.corporation_id = ? order by start_date desc limit 500'
   
-  const result = await app.mysql.query(query, [req.params.id, offset]) 
+  const result = await app.mysql.query(query, [req.params.id]) 
   
-  return { json: {info: info, page: page, characters: result} } 
+  return { json: {characters: result} } 
 }


### PR DESCRIPTION
completes #24

Should need some review! I checked your code style and tried my best to match as possible as I can, but there can be some improvements.

SQL code is from `puglist.js`, so maybe this code will works well.

I won't tested this code since I don't have any test environment... 

### path:
1. /api/corpdeparted/:id ?page=`number` fetches character who departed the corporation, with 50 offset. 
2. /api/corpjoined/:id ?page=`number` fetches character who joined the corporation, with 50 offset.

any review is welcomed!