### PR TITLE
Update listen_redisq.js to new redisq url

### DIFF
--- a/cron/listen_redisq.js
+++ b/cron/listen_redisq.js
@@ -6,7 +6,7 @@ module.exports = {
 const entity = require('../classes/entity.js');
 
 async function f(app) {
-    let url = 'https://redisq.zkillboard.com/listen.php?ttw=5&queueID=' + process.env.redisqID;
+    let url = 'https://zkillredisq.stream/listen.php?ttw=5&queueID=' + process.env.redisqID;
     try {
         do {
             let res = await app.phin(url);


### PR DESCRIPTION
This pull request updates the URL used in the `cron/listen_redisq.js` file to point to a new endpoint for the RedisQ service.

* **Updated RedisQ URL**:
  - Changed the URL from `https://redisq.zkillboard.com/listen.php` to `https://zkillredisq.stream/listen.php` in the `f` function to reflect the new endpoint.