### PR TITLE
fix: trim autocomplete

### DIFF
--- a/www/public/js/site.js
+++ b/www/public/js/site.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
     $('#autocomplete').autocomplete({
       autoSelectFirst: true,
       serviceUrl: function(query) {
-        return '/autocomplete/' + encodeURIComponent(query.trim().toLowerCase());
+        return '/autocomplete/' + encodeURIComponent(query.trimStart().toLowerCase());
       },
       ajaxSettings: {
         type: 'GET',

--- a/www/public/js/site.js
+++ b/www/public/js/site.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
     $('#autocomplete').autocomplete({
       autoSelectFirst: true,
       serviceUrl: function(query) {
-        return '/autocomplete/' + encodeURIComponent(query.toLowerCase());
+        return '/autocomplete/' + encodeURIComponent(query.trim().toLowerCase());
       },
       ajaxSettings: {
         type: 'GET',


### PR DESCRIPTION
add .trim() to autocomplete calls to fix pasting in a character name with leading spaces returning no search results